### PR TITLE
Job state is stored to HA storage dir

### DIFF
--- a/src/main/java/com/espro/flink/consul/ConsulHaServices.java
+++ b/src/main/java/com/espro/flink/consul/ConsulHaServices.java
@@ -158,7 +158,7 @@ public class ConsulHaServices implements HighAvailabilityServices {
 
     @Override
     public JobGraphStore getJobGraphStore() throws Exception {
-        return new ConsulSubmittedJobGraphStore(client, jobGraphsPath());
+        return new ConsulSubmittedJobGraphStore(configuration, client, jobGraphsPath());
 	}
 
 	@Override

--- a/src/main/java/com/espro/flink/consul/checkpoint/ConsulCheckpointRecoveryFactory.java
+++ b/src/main/java/com/espro/flink/consul/checkpoint/ConsulCheckpointRecoveryFactory.java
@@ -1,16 +1,18 @@
 package com.espro.flink.consul.checkpoint;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.espro.flink.consul.configuration.ConsulHighAvailabilityOptions;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
-import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
+import org.apache.flink.runtime.zookeeper.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.util.Preconditions;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.espro.flink.consul.configuration.ConsulHighAvailabilityOptions;
 
 public final class ConsulCheckpointRecoveryFactory implements CheckpointRecoveryFactory {
 
@@ -24,8 +26,8 @@ public final class ConsulCheckpointRecoveryFactory implements CheckpointRecovery
 
 	@Override
 	public CompletedCheckpointStore createCheckpointStore(JobID jobId, int maxNumberOfCheckpointsToRetain, ClassLoader userClassLoader) throws Exception {
-		RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage =
-			ZooKeeperUtils.createFileSystemStateStorage(configuration, "completedCheckpoint");
+        RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = new FileSystemStateStorageHelper<>(
+                HighAvailabilityServicesUtils.getClusterHighAvailableStoragePath(configuration), "completedCheckpoint");
 
 		return new ConsulCompletedCheckpointStore(client, checkpointsPath(), jobId, maxNumberOfCheckpointsToRetain, stateStorage);
 	}

--- a/src/main/java/com/espro/flink/consul/jobgraph/ConsulSubmittedJobGraphStore.java
+++ b/src/main/java/com/espro/flink/consul/jobgraph/ConsulSubmittedJobGraphStore.java
@@ -23,6 +23,14 @@ import org.slf4j.LoggerFactory;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.kv.model.GetBinaryValue;
 
+/**
+ * Stores the state of the job graph to the configured HA storage directory and only a pointer (RetrievableStateHandle) of the state to
+ * Consul.
+ *
+ * @see RetrievableStateHandle
+ * @see FileSystemStateStorageHelper
+ * @see HighAvailabilityServicesUtils#getClusterHighAvailableStoragePath(Configuration)
+ */
 public final class ConsulSubmittedJobGraphStore implements JobGraphStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsulSubmittedJobGraphStore.class);
@@ -55,9 +63,9 @@ public final class ConsulSubmittedJobGraphStore implements JobGraphStore {
         RetrievableStateHandle<JobGraph> stateHandle = jobGraphStateStorage.store(jobGraph);
 
         boolean success = false;
-        // Write state handle (not the actual state) to Consul. This is expected to be
-        // smaller than the state itself.
         try {
+            // Write state handle (not the actual state) to Consul. This is expected to be
+            // smaller than the state itself.
             byte[] bytes = InstantiationUtil.serializeObject(stateHandle);
             LOG.debug("{} bytes will be written to Consul.", bytes.length);
             Boolean response = client.setKVBinaryValue(path(jobGraph.getJobID()), bytes).getValue();

--- a/src/main/java/com/espro/flink/consul/jobgraph/ConsulSubmittedJobGraphStore.java
+++ b/src/main/java/com/espro/flink/consul/jobgraph/ConsulSubmittedJobGraphStore.java
@@ -1,30 +1,43 @@
 package com.espro.flink.consul.jobgraph;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
+import org.apache.flink.runtime.zookeeper.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.kv.model.GetBinaryValue;
 
 public final class ConsulSubmittedJobGraphStore implements JobGraphStore {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ConsulSubmittedJobGraphStore.class);
+
 	private final ConsulClient client;
 	private final String jobgraphsPath;
+    private final RetrievableStateStorageHelper<JobGraph> jobGraphStateStorage;
     private JobGraphListener listener;
 
-	public ConsulSubmittedJobGraphStore(ConsulClient client, String jobgraphsPath) {
+    public ConsulSubmittedJobGraphStore(Configuration configuration, ConsulClient client, String jobgraphsPath) throws IOException {
 		this.client = Preconditions.checkNotNull(client, "client");
 		this.jobgraphsPath = Preconditions.checkNotNull(jobgraphsPath, "jobgraphsPath");
-		Preconditions.checkArgument(jobgraphsPath.endsWith("/"), "jobgraphsPath must end with /");
+        Preconditions.checkArgument(jobgraphsPath.endsWith("/"), "jobgraphsPath must end with /");
+        this.jobGraphStateStorage = new FileSystemStateStorageHelper<>(
+                HighAvailabilityServicesUtils.getClusterHighAvailableStoragePath(configuration), "jobGraph");
 	}
 
 	@Override
@@ -34,33 +47,56 @@ public final class ConsulSubmittedJobGraphStore implements JobGraphStore {
 
 	@Override
 	public void stop() throws Exception {
-
+        // Nothing to do here
 	}
 
 	@Override
 	public void putJobGraph(JobGraph jobGraph) throws Exception {
-		byte[] bytes = InstantiationUtil.serializeObject(jobGraph);
+        RetrievableStateHandle<JobGraph> stateHandle = jobGraphStateStorage.store(jobGraph);
+
+        // Write state handle (not the actual state) to Consul. This is expected to be
+        // smaller than the state itself.
+        byte[] bytes = InstantiationUtil.serializeObject(stateHandle);
+        LOG.debug("{} bytes will be written to Consul.", bytes.length);
         client.setKVBinaryValue(path(jobGraph.getJobID()), bytes);
         this.listener.onAddedJobGraph(jobGraph.getJobID());
 	}
 
 	@Override
     public JobGraph recoverJobGraph(JobID jobId) throws Exception {
-		GetBinaryValue value = client.getKVBinaryValue(path(jobId)).getValue();
+        return getStateHandle(jobId).retrieveState();
+    }
+
+    private RetrievableStateHandle<JobGraph> getStateHandle(JobID jobId) throws FlinkException {
+        GetBinaryValue value = client.getKVBinaryValue(path(jobId)).getValue();
 		if (value != null) {
 			try {
-				return InstantiationUtil.deserializeObject(value.getValue(), Thread.currentThread().getContextClassLoader());
+                return InstantiationUtil.deserializeObject(value.getValue(),
+                        Thread.currentThread().getContextClassLoader());
 			} catch (Exception e) {
 				throw new FlinkException("Could not deserialize SubmittedJobGraph for Job " + jobId.toString(), e);
 			}
 		} else {
 			throw new FlinkException("Could not retrieve SubmittedJobGraph for Job " + jobId.toString());
 		}
-	}
+    }
 
 	@Override
     public void removeJobGraph(JobID jobId) throws Exception {
-		client.deleteKVValue(path(jobId));
+        RetrievableStateHandle<JobGraph> stateHandle = null;
+        try {
+            stateHandle = getStateHandle(jobId);
+        } catch (FlinkException e) {
+            LOG.warn("Could not retrieve the state handle from Consul {}.", path(jobId), e);
+        }
+
+        // First remove state from Consul (Independent of errors when reading the state handler)
+        client.deleteKVValue(path(jobId));
+
+        if (stateHandle != null) {
+            stateHandle.discardState();
+        }
+
 		listener.onRemovedJobGraph(jobId);
 	}
 


### PR DESCRIPTION
Faced the problem on our production like system. The whole job state was stored to Consul and leads to the problem that the 512byte value threshold was reached. So i changed the logic that only a pointer (RetrievableStateHandle) is stored in Consul.