### PR TITLE
Checkpoints and checkpoint states are removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:1.10.19"
     testCompile 'com.pszymczyk.consul:embedded-consul:2.1.4'
+    testCompile 'org.awaitility:awaitility:4.0.3'
+    testCompile "org.apache.flink:flink-runtime_$scalaVersion:$flinkVersion:tests"
+    testCompile "org.apache.flink:flink-test-utils_$scalaVersion:$flinkVersion"
 
     shadow 'com.ecwid.consul:consul-api:1.4.5'
 }

--- a/src/main/java/com/espro/flink/consul/ConsulHaServices.java
+++ b/src/main/java/com/espro/flink/consul/ConsulHaServices.java
@@ -142,7 +142,7 @@ public class ConsulHaServices implements HighAvailabilityServices {
 
 	@Override
 	public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
-		return new ConsulCheckpointRecoveryFactory(client, configuration);
+        return new ConsulCheckpointRecoveryFactory(client, configuration, executor);
 	}
 
 	@Override

--- a/src/main/java/com/espro/flink/consul/checkpoint/ConsulCheckpointRecoveryFactory.java
+++ b/src/main/java/com/espro/flink/consul/checkpoint/ConsulCheckpointRecoveryFactory.java
@@ -1,5 +1,7 @@
 package com.espro.flink.consul.checkpoint;
 
+import java.util.concurrent.Executor;
+
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -18,9 +20,11 @@ public final class ConsulCheckpointRecoveryFactory implements CheckpointRecovery
 
 	private final ConsulClient client;
 	private final Configuration configuration;
+    private final Executor executor;
 
-	public ConsulCheckpointRecoveryFactory(ConsulClient client, Configuration configuration) {
-		this.client = Preconditions.checkNotNull(client, "client");
+    public ConsulCheckpointRecoveryFactory(ConsulClient client, Configuration configuration, Executor executor) {
+        this.executor = executor;
+        this.client = Preconditions.checkNotNull(client, "client");
 		this.configuration = Preconditions.checkNotNull(configuration, "configuration");
 	}
 
@@ -29,7 +33,7 @@ public final class ConsulCheckpointRecoveryFactory implements CheckpointRecovery
         RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = new FileSystemStateStorageHelper<>(
                 HighAvailabilityServicesUtils.getClusterHighAvailableStoragePath(configuration), "completedCheckpoint");
 
-		return new ConsulCompletedCheckpointStore(client, checkpointsPath(), jobId, maxNumberOfCheckpointsToRetain, stateStorage);
+        return new ConsulCompletedCheckpointStore(client, checkpointsPath(), jobId, maxNumberOfCheckpointsToRetain, stateStorage, executor);
 	}
 
 	@Override

--- a/src/test/java/com/espro/flink/consul/checkpoint/CheckpointTestHelper.java
+++ b/src/test/java/com/espro/flink/consul/checkpoint/CheckpointTestHelper.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) SABIO GmbH, Hamburg 2020 - All rights reserved
+ */
+package com.espro.flink.consul.checkpoint;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.checkpoint.CheckpointProperties;
+import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreTest;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreTest.TestOperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+
+/**
+ * Some of these methods and class are taken from flink test module. Providing simple use of the checkpointing.
+ */
+public class CheckpointTestHelper {
+
+    /**
+     * Taken from {@link CompletedCheckpointStoreTest}.
+     *
+     * @param id - checkpijt id
+     * @param sharedStateRegistry - shared state registry
+     * @return {@link TestCompletedCheckpoint}
+     */
+    public static TestCompletedCheckpoint createCheckpoint(long id, SharedStateRegistry sharedStateRegistry) {
+
+        int numberOfStates = 4;
+        CheckpointProperties props = CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION);
+
+        OperatorID operatorID = new OperatorID();
+
+        Map<OperatorID, OperatorState> operatorGroupState = new HashMap<>();
+        OperatorState operatorState = new OperatorState(operatorID, numberOfStates, numberOfStates);
+        operatorGroupState.put(operatorID, operatorState);
+
+        for (int i = 0; i < numberOfStates; i++) {
+            OperatorSubtaskState subtaskState = new TestOperatorSubtaskState();
+
+            operatorState.putState(i, subtaskState);
+        }
+
+        operatorState.registerSharedStates(sharedStateRegistry);
+
+        return new TestCompletedCheckpoint(new JobID(), id, 0, operatorGroupState, props);
+    }
+
+    /**
+     * Taken from {@link CompletedCheckpointStoreTest}.
+     *
+     * @param completedCheckpoint
+     */
+    public static void verifyCheckpointDiscarded(TestCompletedCheckpoint completedCheckpoint) {
+        assertTrue(completedCheckpoint.isDiscarded());
+        verifyCheckpointDiscarded(completedCheckpoint.getOperatorStates().values());
+    }
+
+    /**
+     * Taken from {@link CompletedCheckpointStoreTest}.
+     *
+     * @param operatorStates
+     */
+    private static void verifyCheckpointDiscarded(Collection<OperatorState> operatorStates) {
+        for (OperatorState operatorState : operatorStates) {
+            for (OperatorSubtaskState subtaskState : operatorState.getStates()) {
+                assertTrue(((TestOperatorSubtaskState) subtaskState).isDiscarded());
+            }
+        }
+    }
+
+    protected static class TestCompletedCheckpoint extends CompletedCheckpoint {
+
+        private static final long serialVersionUID = 4211419809665983026L;
+
+        private boolean isDiscarded;
+
+        // Latch for test variants which discard asynchronously
+        private transient final CountDownLatch discardLatch = new CountDownLatch(1);
+
+        public TestCompletedCheckpoint(
+                JobID jobId,
+                long checkpointId,
+                long timestamp,
+                Map<OperatorID, OperatorState> operatorGroupState,
+                CheckpointProperties props) {
+
+            super(jobId, checkpointId, timestamp, Long.MAX_VALUE, operatorGroupState, null, props,
+                    new TestCompletedCheckpointStorageLocation());
+        }
+
+        @Override
+        public boolean discardOnSubsume() throws Exception {
+            if (super.discardOnSubsume()) {
+                discard();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean discardOnShutdown(JobStatus jobStatus) throws Exception {
+            if (super.discardOnShutdown(jobStatus)) {
+                discard();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        void discard() {
+            if (!isDiscarded) {
+                this.isDiscarded = true;
+
+                if (discardLatch != null) {
+                    discardLatch.countDown();
+                }
+            }
+        }
+
+        public boolean isDiscarded() {
+            return isDiscarded;
+        }
+
+        public void awaitDiscard() throws InterruptedException {
+            if (discardLatch != null) {
+                discardLatch.await();
+            }
+        }
+
+        public boolean awaitDiscard(long timeout) throws InterruptedException {
+            if (discardLatch != null) {
+                return discardLatch.await(timeout, TimeUnit.MILLISECONDS);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TestCompletedCheckpoint that = (TestCompletedCheckpoint) o;
+
+            return getJobId().equals(that.getJobId())
+                    && getCheckpointID() == that.getCheckpointID();
+        }
+
+        @Override
+        public int hashCode() {
+            return getJobId().hashCode() + (int) getCheckpointID();
+        }
+    }
+}

--- a/src/test/java/com/espro/flink/consul/checkpoint/ConsulCompletedCheckpointStoreTest.java
+++ b/src/test/java/com/espro/flink/consul/checkpoint/ConsulCompletedCheckpointStoreTest.java
@@ -9,14 +9,20 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static com.espro.flink.consul.checkpoint.CheckpointTestHelper.verifyCheckpointDiscarded;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
@@ -26,14 +32,17 @@ import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
 import org.apache.flink.shaded.guava18.com.google.common.io.Files;
 import org.apache.flink.util.InstantiationUtil;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,35 +50,43 @@ import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.kv.model.GetBinaryValue;
 import com.espro.flink.consul.AbstractConsulTest;
+import com.espro.flink.consul.checkpoint.CheckpointTestHelper.TestCompletedCheckpoint;
 
 public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
+
+    private static final String CHECKPOINT_STORAGE_PREFIX = "cp";
 
     private ConsulClient client;
     private File tempDir;
     private RetrievableStateStorageHelper<CompletedCheckpoint> storage;
     private String checkpointsPath = "test-checkpoints/";
 
+    private static Executor executor = Executors.newSingleThreadExecutor();
+
+    private static AtomicLong checkpointIdCounter = new AtomicLong();
+
     @Before
     public void setup() throws IOException {
         client = new ConsulClient(String.format("localhost:%d", consul.getHttpPort()));
         tempDir = Files.createTempDir();
-        storage = new FileSystemStateStorageHelper<>(new Path(tempDir.getPath()), "cp");
+        storage = new FileSystemStateStorageHelper<>(new Path(tempDir.getPath()), CHECKPOINT_STORAGE_PREFIX);
     }
 
     @Test
     public void testConfiguration() throws Exception {
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 10, storage);
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 10, storage, executor);
         assertEquals(10, store.getMaxNumberOfRetainedCheckpoints());
         assertTrue(store.requiresExternalizedCheckpoints());
     }
 
     @Test
     public void testAddCheckpoint() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
 
-        CompletedCheckpoint checkpoint = createCheckpoint(jobID, 1l);
+        CompletedCheckpoint checkpoint = CheckpointTestHelper.createCheckpoint((int)checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
 
         assertEquals(0, store.getNumberOfRetainedCheckpoints());
 
@@ -85,11 +102,12 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
 
     @Test
     public void testAllCheckpoints() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 3, storage);
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 3, storage, executor);
 
-        CompletedCheckpoint checkpoint1 = createCheckpoint(jobID, 1l);
-        CompletedCheckpoint checkpoint2 = createCheckpoint(jobID, 2l);
+        CompletedCheckpoint checkpoint1 = CheckpointTestHelper.createCheckpoint((int)checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
+        CompletedCheckpoint checkpoint2 = CheckpointTestHelper.createCheckpoint((int)checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
 
         store.addCheckpoint(checkpoint1);
         store.addCheckpoint(checkpoint2);
@@ -105,13 +123,14 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
 
     @Test
     public void testRecovery() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
 
-        CompletedCheckpoint checkpoint = createCheckpoint(jobID, 1l);
+        CompletedCheckpoint checkpoint = CheckpointTestHelper.createCheckpoint((int)checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
         store.addCheckpoint(checkpoint);
 
-        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
         newStore.recover();
 
         CompletedCheckpoint latestCheckpoint = newStore.getLatestCheckpoint(false);
@@ -124,7 +143,7 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
     public void testRecovery_retryAfterException() throws Exception {
         JobID jobID = JobID.generate();
 
-        CompletedCheckpoint checkpoint = createCheckpoint(jobID, 1l);
+        CompletedCheckpoint checkpoint = createCheckpoint(jobID);
 
         ConsulClient consulClient = mock(ConsulClient.class);
         when(consulClient.getKVKeysOnly(checkpointsPath + jobID.toString())).thenReturn(
@@ -141,7 +160,8 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
             )));
             return new Response<>(binaryValue, 0L, false, 0L);
         });
-        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(consulClient, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(consulClient, checkpointsPath, jobID, 1, storage,
+                executor);
 
         newStore.recover();
 
@@ -153,14 +173,15 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
 
     @Test
     public void testShutdown() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
 
-        CompletedCheckpoint checkpoint = createCheckpoint(jobID, 1l);
+        CompletedCheckpoint checkpoint = CheckpointTestHelper.createCheckpoint((int)checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
         store.addCheckpoint(checkpoint);
         store.shutdown(JobStatus.FINISHED);
 
-        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        ConsulCompletedCheckpointStore newStore = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
         newStore.recover();
 
         assertEquals(0, newStore.getAllCheckpoints().size());
@@ -168,24 +189,42 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
 
     @Test
     public void testRemoveSubsumedCheckpoint() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
+        // GIVEN job id
         JobID jobID = JobID.generate();
-        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage);
+        // GIVEN ConsulCompletedCheckpointStore
+        ConsulCompletedCheckpointStore store = new ConsulCompletedCheckpointStore(client, checkpointsPath, jobID, 1, storage, executor);
 
-        CompletedCheckpoint checkpoint1 = createCheckpoint(jobID, 1l);
-        CompletedCheckpoint checkpoint2 = createCheckpoint(jobID, 2l);
+        // GIVEN two checkpoints
+        TestCompletedCheckpoint checkpoint1 = CheckpointTestHelper.createCheckpoint((int) checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
+        TestCompletedCheckpoint checkpoint2 = CheckpointTestHelper.createCheckpoint((int) checkpointIdCounter.incrementAndGet(), sharedStateRegistry);
 
+        // WHEN adding first checkpoint it is present in temp dir
         store.addCheckpoint(checkpoint1);
+        assertEquals(1, tempDir.list().length);
+
+        // WHEN adding first checkpoint
         store.addCheckpoint(checkpoint2);
 
+        // THEN first checkpoint is removed from temp dir and only second checkpoint is present
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .ignoreExceptions()
+                .untilAsserted(() -> verifyCheckpointDiscarded(checkpoint1));
+        assertEquals(1, tempDir.list().length);
+
+        // THEN last checkpoint is equal to the second checkpoint
         CompletedCheckpoint latestCheckpoint = store.getLatestCheckpoint(false);
         assertNotNull(latestCheckpoint);
         assertEquals(checkpoint2, latestCheckpoint);
         assertSame(checkpoint2, latestCheckpoint);
 
+        // THEN the storage returns only one checkpoint
         assertEquals(1, store.getAllCheckpoints().size());
     }
 
-    private CompletedCheckpoint createCheckpoint(JobID jobID, long checkpointId) {
+    private static CompletedCheckpoint createCheckpoint(JobID jobID) {
+        long checkpointId = checkpointIdCounter.incrementAndGet();
         long timestamp = checkpointId;
         long completionTimestamp = checkpointId;
         CheckpointProperties chkProps = CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION);
@@ -195,6 +234,8 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
     }
 
     static class TestStateHandle implements RetrievableStateHandle<CompletedCheckpoint>, Serializable {
+
+        private static final long serialVersionUID = -4436799794096849748L;
 
         private List<Object> behavior;
         private transient Iterator<Object> iter;
@@ -239,7 +280,9 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
         }
     }
 
-    public static class TestCompletedCheckpointStorageLocation implements CompletedCheckpointStorageLocation {
+    public static class TestCompletedCheckpointStorageLocationA implements CompletedCheckpointStorageLocation {
+
+        private static final long serialVersionUID = -7052501192159437692L;
 
         private String externalPointer = UUID.randomUUID().toString();
 
@@ -265,8 +308,8 @@ public class ConsulCompletedCheckpointStoreTest extends AbstractConsulTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof TestCompletedCheckpointStorageLocation) {
-                TestCompletedCheckpointStorageLocation other = (TestCompletedCheckpointStorageLocation) obj;
+            if (obj instanceof TestCompletedCheckpointStorageLocationA) {
+                TestCompletedCheckpointStorageLocationA other = (TestCompletedCheckpointStorageLocationA) obj;
                 return this.externalPointer.equals(other.externalPointer);
             }
             return false;


### PR DESCRIPTION
I faced this problem on our near production environment, because the S3 has no disk space anymore after running a few days. Only the configured number of checkpoints is stored due to the "num-retained" property.

https://ci.apache.org/projects/flink/flink-docs-release-1.12/dev/stream/state/checkpointing.html#state-checkpoints-num-retained